### PR TITLE
Use relative URLs in the UI

### DIFF
--- a/pkg/zipkin-ui/static/index.html
+++ b/pkg/zipkin-ui/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Webpack App</title>
-  <link href="/app-e5d412b21f914bbdf087.min.css" rel="stylesheet"></head>
+  <link href="app-e5d412b21f914bbdf087.min.css" rel="stylesheet"></head>
   <body>
-  <script type="text/javascript" src="/app-e5d412b21f914bbdf087.min.js"></script></body>
+  <script type="text/javascript" src="app-e5d412b21f914bbdf087.min.js"></script></body>
 </html>


### PR DESCRIPTION
Absolute URLs don't work when the file is proxied under some other URL (e.g. `/admin/loki`)