### PR TITLE
Use shfmt v1.3.0 instead of gopkg.in's v1.

### DIFF
--- a/loki-build/Dockerfile
+++ b/loki-build/Dockerfile
@@ -4,13 +4,16 @@ RUN apt-get update && apt-get install -y file jq && \
 RUN go clean -i net && \
 	go install -tags netgo std && \
 	go install -race -tags netgo std
+RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
+	echo "b1925c2c405458811f0c227266402cf1868b4de529f114722c2e3a5af4ac7bb2  shfmt" | sha256sum -c && \
+	chmod +x shfmt && \
+	mv shfmt /usr/bin
 RUN go get -tags netgo \
 		github.com/fzipp/gocyclo \
 		github.com/golang/lint/golint \
 		github.com/kisielk/errcheck \
 		github.com/client9/misspell/cmd/misspell \
-		github.com/jteeuwen/go-bindata/go-bindata \
-		gopkg.in/mvdan/sh.v1/cmd/shfmt && \
+		github.com/jteeuwen/go-bindata/go-bindata && \
 	rm -rf /go/pkg /go/src
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]


### PR DESCRIPTION
This PR fixes [build issues in `master`](https://circleci.com/gh/weaveworks-experiments/loki/32).

----
As mentioned on:
- weaveworks/build-tools#99 (comment)

and raised on:
- mvdan/sh#107

`gopkg.in` currently does not behave as it should for `shfmt`, which leads to build failures like:

```
Step 4 : RUN go get -tags netgo 		github.com/fzipp/gocyclo 		github.com/golang/lint/golint 		github.com/kisielk/errcheck 		github.com/client9/misspell/cmd/misspell 		github.com/jteeuwen/go-bindata/go-bindata 		gopkg.in/mvdan/sh.v1/cmd/shfmt && 	rm -rf /go/pkg /go/src
 ---> Running in 964799cc06ff
package github.com/mvdan/sh/fileutil: code in directory /go/src/github.com/mvdan/sh/fileutil expects import "mvdan.cc/sh/fileutil"
package github.com/mvdan/sh/syntax: code in directory /go/src/github.com/mvdan/sh/syntax expects import "mvdan.cc/sh/syntax"
[...]
```

This change works around the issue by simply downloading the binary, which is less involved than building from the tag, and more deterministic than using a moving target, e.g.:

```
go get github.com/mvdan/sh/cmd/shfmt
```